### PR TITLE
Wait for Livestreamer's http server to accept connections

### DIFF
--- a/streamer/scripts/wait_for_host.sh
+++ b/streamer/scripts/wait_for_host.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+port=$1
+
+while ! echo exit | nc localhost $port &> /dev/null; do
+    sleep .5
+done

--- a/streamer/streaming.py
+++ b/streamer/streaming.py
@@ -57,6 +57,12 @@ class Stream:
             stderr=sys.stderr.fileno(),
         )
 
+        # Waiting for livestreamer's http server to accept requests
+        subprocess.call([
+            './scripts/wait_for_host.sh',
+            '{}'.format(self.port)
+        ])
+
     def watch(self):
         self.proxy = Proxy(self)
         self.proxy.start()


### PR DESCRIPTION
`POST`s on `/streamer/streams` were returning before Livestreamer was ready
Consecutive watch requests could then fail if sent too quickly

Fixed this behavior by naively waiting for Livestreamer's http server to accept connections before returning from the `POST` request
