### PR TITLE
Monitor processes and notify stream readiness

### DIFF
--- a/streamer/api.py
+++ b/streamer/api.py
@@ -6,14 +6,7 @@ from events import Event, EventNotifier
 streams_by_id = {}
 notifier = EventNotifier()
 
-def poll_streams():
-    dead_streams = [
-        id for id, stream in streams_by_id.items()
-        if not stream.alive()
-    ]
 
-    for id in dead_streams:
-        del streams_by_id[id]
 
 from flask import Flask, request, jsonify, Response
 
@@ -38,7 +31,6 @@ def with_stream(fn):
     return wrapped
 
 @app.route('/streams', methods=['GET'])
-@preprocess(poll_streams)
 def streams():
     return Response(
         dumps([
@@ -49,7 +41,6 @@ def streams():
     )
 
 @app.route('/streams/<int:stream_id>', methods=['GET'])
-@preprocess(poll_streams)
 @with_stream
 def stream(stream):
     return Response(
@@ -58,7 +49,6 @@ def stream(stream):
     )
 
 @app.route('/streams/<int:stream_id>', methods=['DELETE'])
-@preprocess(poll_streams)
 @with_stream
 def unmonitor(stream):
     stream.unwatch()
@@ -73,7 +63,6 @@ def unmonitor(stream):
     )
 
 @app.route('/streams/<int:stream_id>/watch', methods=['POST'])
-@preprocess(poll_streams)
 @with_stream
 def watch(stream):
     stream.watch()
@@ -88,7 +77,6 @@ def watch(stream):
     )
 
 @app.route('/streams/<int:stream_id>/unwatch', methods=['POST'])
-@preprocess(poll_streams)
 @with_stream
 def unwatch(stream):
     stream.unwatch()
@@ -104,7 +92,6 @@ def unwatch(stream):
 
 @app.route('/streams', methods=['POST'])
 @validate_json_request('monitor')
-@preprocess(poll_streams)
 def monitor(payload):
     stream = Stream(
         payload['channel'],

--- a/streamer/events.py
+++ b/streamer/events.py
@@ -8,6 +8,7 @@ class Event:
     UNMONITORED = 'unmonitored'
     WATCHED     = 'watched'
     UNWATCHED   = 'unwatched'
+    READY       = 'ready'
 
     def __init__(self, type, data):
         self.data = data

--- a/streamer/process.py
+++ b/streamer/process.py
@@ -1,0 +1,20 @@
+import sys
+import subprocess
+
+from threading import Thread
+
+def start_process(command, on_exit):
+    process = subprocess.Popen(
+        command,
+        stdout=sys.stderr.fileno(),
+        stderr=sys.stderr.fileno(),
+    )
+
+    def run():
+        process.wait()
+        on_exit()
+
+    thread = Thread(target=run)
+    thread.start()
+
+    return process

--- a/streamer/utils.py
+++ b/streamer/utils.py
@@ -39,16 +39,3 @@ def validate_json_request(schema_name):
         return wrapped
 
     return decorate
-
-def preprocess(action):
-
-    def decorate(fn):
-        @wraps(fn)
-
-        def wrapped(*args, **kwargs):
-            action()
-            return fn(*args, **kwargs)
-
-        return wrapped
-
-    return decorate

--- a/streamer/ws.py
+++ b/streamer/ws.py
@@ -25,7 +25,7 @@ class WebSocketsServer:
     def run(self):
         server = websockets.serve(
             self.socket_handler,
-            port=4242
+            port=self.port
         )
 
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
#18

Now sending websocket events on `livestreamer` and `vlc` deaths
Also notifying when the HLS proxy is ready

I really wish I could implement it in an _event based_ way
Using polling threads seems kind of _hackish_

Time to change the server's stack I guess :D
