### PR TITLE
Now using FFmpeg instead of VLC to dump HLS segments

### DIFF
--- a/streamer/Dockerfile
+++ b/streamer/Dockerfile
@@ -1,14 +1,15 @@
 FROM python:3
 
-# Install vlc
-RUN apt-get update && apt-get install -y vlc
-# Hackish but simplest way I found to allow VLC to run as root
-RUN sed -i 's/geteuid/getppid/' /usr/bin/vlc
-
 RUN pip install \
     Flask \
     jsonschema \
     websockets
+
+# Install netcat and ffmpeg reqs
+RUN apt-get update -y && apt-get install -y \
+    netcat \
+    yasm \
+    nasm
 
 # Install my fork of Livestreamer
 RUN apt-get install -y unzip
@@ -18,8 +19,15 @@ RUN unzip /tmp/livestreamer.zip -d /tmp
 RUN cd /tmp/livestreamer-${branch} && python3 setup.py install
 RUN rm -rf /tmp/livestreamer.zip /tmp/livestreamer-${branch}
 
-# Install netcat
-RUN apt-get install -y netcat
+ENV FFMPEG_ARCHIVE_URL  http://www.ffmpeg.org/releases/ffmpeg-3.1.tar.gz
+ENV FFMPEG_BUILD_DIR    /ffmpeg-build
+ENV FFMPEG_DIST_DIR     /ffmpeg
+RUN mkdir ${FFMPEG_BUILD_DIR} &&\
+    curl -L ${FFMPEG_ARCHIVE_URL} | tar xz -C ${FFMPEG_BUILD_DIR} --strip-components 1 &&\
+    cd ${FFMPEG_BUILD_DIR} &&\
+    ./configure --prefix=${FFMPEG_DIST_DIR} &&\
+    make -j$(nproc) install > build.log &&\
+    rm -rf ${FFMPEG_BUILD_DIR}
 
-WORKDIR "/streamer"
+WORKDIR /streamer
 ENTRYPOINT ["./api.py"]


### PR DESCRIPTION
FFmpeg is more lightweight and easier to build
Funnily enough, using FFmpeg also solved a receiver issue where the Chromecast had to wait for the manifest file to contain every segment entry to be able to play the video.
I guess VLC was doing something wrong/not compliant with the way the Chromecast implemented HLS decoding
This is really nice because on the user side, it makes the casting process a lot faster
