### PR TITLE
Improve chat performances

### DIFF
--- a/frontend/receiver/tags/chat.tag
+++ b/frontend/receiver/tags/chat.tag
@@ -101,7 +101,7 @@
         self.addMessage(message);
       }
 
-      messageQueue = messageQueue.slice(i, messageQueue.length);
+      messageQueue = messageQueue.splice(0, i + 1);
 
       self.update();
       self.root.scrollTop = self.root.scrollHeight;


### PR DESCRIPTION
Using `splice` instead of `slice` to remove messages from the queue
Turns out it is a lot more memory efficient in this case and therefore avoids major GC passes
##### RAM evolution
###### slice

![image](https://cloud.githubusercontent.com/assets/2079561/16501143/4e511ada-3f08-11e6-800d-76f90c3cceb1.png)
###### splice

![image](https://cloud.githubusercontent.com/assets/2079561/16501176/707a31c8-3f08-11e6-8976-2aa396e68437.png)
