### PR TITLE
Now using a valid client-id for twitch API calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       OUTPUT_DIRECTORY: '/data/video'
       SERVER_PATH: '/video'
       OUTPUT_INDEX_FILE_NAME: 'stream.m3u8'
+      TWITCH_CLIENT_ID: 'Your Twitch app client id'
 
   irc-relay:
     image: globidocker/twitch-irc

--- a/streamer/streaming.py
+++ b/streamer/streaming.py
@@ -1,9 +1,13 @@
 import subprocess
 import socket
-import livestreamer
+import os
 
 from hls import Proxy
 from process import start_process
+from livestreamer import Livestreamer
+
+TWITCH_CLIENT_ID = os.environ['TWITCH_CLIENT_ID']
+TWITCH_CLIENT_HTTP_HEADER = 'Client-ID={}'.format(TWITCH_CLIENT_ID)
 
 LIVESTREAMER_COMMAND = lambda url, quality, port: [
     'livestreamer',
@@ -11,6 +15,7 @@ LIVESTREAMER_COMMAND = lambda url, quality, port: [
     quality,
     '--player-external-http',
     '--player-external-http-port', '{}'.format(port),
+    '--http-header', TWITCH_CLIENT_HTTP_HEADER,
     '--yes-run-as-root'
 ]
 
@@ -41,8 +46,11 @@ class Stream:
         self.proxy = None
         self.on_exit = None
 
+        self.session = Livestreamer()
+        self.session.set_option('http-headers', TWITCH_CLIENT_HTTP_HEADER)
+
     def is_available(self):
-        streams = livestreamer.streams(self.url)
+        streams = self.session.streams(self.url)
         return self.quality in streams
 
     def monitor(self, on_exit):


### PR DESCRIPTION
Since Livestreamer depends on Twitch's API, it wasn't able to fetch stream information anymore because Twitch made authentication mandatory for API calls as of today-ish

I overlooked server side when adding authentication for client-side API calls (@72162bf472e594f81e4743169cc0240c0883fd4d)

My bad
